### PR TITLE
make room for the NULL byte

### DIFF
--- a/git-vain.c
+++ b/git-vain.c
@@ -173,7 +173,7 @@ int spiral_max(int max_side) {
 }
 
 void ammend_commit(char *newCommit, unsigned char *sha, int da, int dc) {
-  char progHash[SHA_DIGEST_LENGTH*2];
+  char progHash[SHA_DIGEST_LENGTH*2+1];
   for(int i=0; i<SHA_DIGEST_LENGTH; i++) {
     sprintf(progHash+i*2, "%02x", sha[i]);
   }


### PR DESCRIPTION
this fixes the length of the progHash to include room for the NULL byte
that all C strings terminate with.

Fixes https://github.com/will/git-vain/issues/1

Disclaimer: I am not a C programmer. There might be a more elegant solution that is obvious to someone who writes C code professionally.